### PR TITLE
Small improvements

### DIFF
--- a/srtp.c
+++ b/srtp.c
@@ -513,6 +513,16 @@ static int srtp_crypt (srtp_session_t *s, uint8_t *buf, size_t len)
     return 0;
 }
 
+/**
+ * Sets the sequence number in the session.
+ * Should be called with the first RTP packet
+ *
+ * @param buf First RTP packet to be encrypted/digested
+ */
+void
+srtp_init_seq (srtp_session_t *s, uint8_t *buf) {
+    s->rtp_seq = rtp_seq(buf);
+}
 
 /**
  * Turns a RTP packet into a SRTP packet: encrypt it, then computes

--- a/srtp.h
+++ b/srtp.h
@@ -74,6 +74,7 @@ int srtp_send (srtp_session_t *s, uint8_t *buf, size_t *lenp, size_t maxsize);
 int srtp_recv (srtp_session_t *s, uint8_t *buf, size_t *lenp);
 int srtcp_send (srtp_session_t *s, uint8_t *buf, size_t *lenp, size_t maxsiz);
 int srtcp_recv (srtp_session_t *s, uint8_t *buf, size_t *lenp);
+void srtp_init_seq (srtp_session_t *s, uint8_t *buf);
 
 # ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request detects if the pcap file is of DLT_LINUX_SLL type and provides a better rtp offset value.

Also it only processes UDP packets using pcap_setfilter, and now it works correctly when the RTP initial sequence number is greater than 0x8000