### PR TITLE
Added srtp flags options, separate key and salt and glib 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 CFLAGS=-g -Os -Wall
+CFLAGS+=`pkg-config --cflags glib-2.0`
+
+LDFLAGS=`pkg-config --libs glib-2.0`
 
 all: srtp.o srtp-decrypt.o
-	$(CC) -o srtp-decrypt srtp-decrypt.o srtp.o -lpcap -lgcrypt
+	$(CC) -o srtp-decrypt srtp-decrypt.o srtp.o $(LDFLAGS) -lpcap -lgcrypt
 
 check:
 	./srtp-decrypt -k aSBrbm93IGFsbCB5b3VyIGxpdHRsZSBzZWNyZXRz < ./marseillaise-srtp.pcap | text2pcap -t "%M:%S." -u 10000,10000 - - > ./marseillaise-rtp.pcap


### PR DESCRIPTION
Hi, while working with rtpengine project we needed to quickly decrypt UNAUTENTICATED_SRTP media and use separately hashed key and salt from rtpengine logs. Here some changes I made for that, including the use of glib 2.0.
