### PR TITLE
fix "rtp header extension len not correct" issue

### DIFF
--- a/srtp.c
+++ b/srtp.c
@@ -468,11 +468,11 @@ static int srtp_crypt (srtp_session_t *s, uint8_t *buf, size_t len)
     {
         uint16_t extlen;
 
-        offset += 2;
-        if (len < offset + 2)
+        offset += 4;
+        if (len < offset)
             return EINVAL;
 
-        memcpy (&extlen, buf + offset, 2);
+        memcpy (&extlen, buf + offset - 2, 2);
         offset += htons (extlen)*4; // skips RTP extension header
     }
 


### PR DESCRIPTION
forget to contribute back, It's been on my local fork for a while.
This fixed the issue reported https://github.com/gteissier/srtp-decrypt/issues/6